### PR TITLE
Polish signing callbacks

### DIFF
--- a/frontend/app/api/trades/[id]/buyer/signing-complete/route.ts
+++ b/frontend/app/api/trades/[id]/buyer/signing-complete/route.ts
@@ -1,0 +1,211 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { SignatureProgress, TradeStatus, TransactionStatus } from "@prisma/client";
+import { clerkClient } from "@clerk/nextjs/server";
+
+import { appUrl, sendEmail } from "@/lib/email";
+import { prisma } from "@/lib/prisma";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function pickFullyExecutedStatus(): (typeof TradeStatus)[keyof typeof TradeStatus] {
+  const TS: any = TradeStatus;
+  return TS.FULLY_EXECUTED ?? TS.ACCEPTED ?? TS.PENDING ?? TS.OFFERED;
+}
+
+function pickTxnAfterBuyerSig(): (typeof TransactionStatus)[keyof typeof TransactionStatus] | null {
+  const TXS: any = TransactionStatus;
+  return TXS.COMPLIANCE_REVIEW ?? TXS.APPROVED ?? TXS.FUNDS_RELEASED ?? null;
+}
+
+async function resolveContact(userId?: string | null) {
+  if (!userId) return { email: "", name: "" };
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { email: true, name: true, clerkId: true } });
+  if (!user) return { email: "", name: "" };
+
+  let { email = "", name = "" } = user;
+
+  if ((!email || !name) && user.clerkId) {
+    try {
+      const clerkUser = await clerkClient.users.getUser(user.clerkId);
+      name = name || clerkUser.firstName || clerkUser.username || "";
+      const primary = clerkUser.emailAddresses?.find(e => e.id === clerkUser.primaryEmailAddressId)?.emailAddress;
+      email = email || primary || clerkUser.emailAddresses?.[0]?.emailAddress || "";
+    } catch {
+      // swallow clerk lookup errors
+    }
+  }
+
+  return { email, name };
+}
+
+function parseEmails(value?: string | null) {
+  if (!value) return [] as string[];
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function formatUsdCents(cents?: number | null) {
+  if (typeof cents !== "number") return "—";
+  return (cents / 100).toLocaleString(undefined, { style: "currency", currency: "USD" });
+}
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const id = (params.id || "").trim();
+  if (!id) {
+    return NextResponse.json({ error: "Missing trade id" }, { status: 400 });
+  }
+
+  const token = req.nextUrl.searchParams.get("token") || "";
+
+  try {
+    const trade = await prisma.trade.findUnique({
+      where: { id },
+      include: {
+        listing: { select: { title: true, district: true } },
+      },
+    });
+
+    if (!trade) {
+      return NextResponse.json({ error: "Trade not found" }, { status: 404 });
+    }
+
+    if (trade.buyerToken && token && token !== trade.buyerToken) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const updated = await prisma.trade.update({
+      where: { id: trade.id },
+      data: {
+        status: pickFullyExecutedStatus(),
+        buyerSignStatus: SignatureProgress.SIGNED,
+        events: {
+          create: {
+            id: randomUUID(),
+            actor: "buyer",
+            kind: "BUYER_SIGNED",
+            payload: {
+              previousStatus: trade.status,
+              buyerSignStatus: trade.buyerSignStatus,
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        buyerUserId: true,
+        sellerUserId: true,
+        buyerToken: true,
+        sellerToken: true,
+        district: true,
+        waterType: true,
+        windowLabel: true,
+        volumeAf: true,
+        pricePerAf: true,
+        transactionId: true,
+      },
+    });
+
+    if (updated.transactionId) {
+      try {
+        const nextStatus = pickTxnAfterBuyerSig();
+        if (nextStatus) {
+          await prisma.transaction.update({ where: { id: updated.transactionId }, data: { status: nextStatus } });
+        }
+      } catch (err) {
+        console.warn("[buyer/signing-complete] transaction update failed", (err as any)?.message);
+      }
+    }
+
+    const [buyerContact, sellerContact] = await Promise.all([
+      resolveContact(updated.buyerUserId),
+      resolveContact(updated.sellerUserId),
+    ]);
+
+    const tradeLinkForSeller = appUrl(
+      `/t/${updated.id}?role=seller${updated.sellerToken ? `&token=${updated.sellerToken}` : ""}&action=buyer-signature-complete`
+    );
+    const tradeLinkForBuyer = appUrl(
+      `/t/${updated.id}?role=buyer${updated.buyerToken ? `&token=${updated.buyerToken}` : ""}&action=buyer-signature-complete`
+    );
+
+    if (sellerContact.email) {
+      const html = `
+        <p>Hi ${sellerContact.name || "Seller"},</p>
+        <p>The buyer just completed their signature. Our team will now review and coordinate with the water district.</p>
+        <p>Track progress here: <a href="${tradeLinkForSeller}">${tradeLinkForSeller}</a></p>
+      `;
+      try {
+        await sendEmail({ to: sellerContact.email, subject: "Buyer signed — pending admin review", html });
+      } catch (err) {
+        console.warn("[buyer/signing-complete] email seller failed", (err as any)?.message);
+      }
+    }
+
+    if (buyerContact.email) {
+      const html = `
+        <p>Hi ${buyerContact.name || "Buyer"},</p>
+        <p>Thanks for signing! Our team will confirm the agreement with the district and keep you posted.</p>
+        <p>You can return to the transaction any time: <a href="${tradeLinkForBuyer}">${tradeLinkForBuyer}</a></p>
+      `;
+      try {
+        await sendEmail({ to: buyerContact.email, subject: "Signature received — we’ll take it from here", html });
+      } catch (err) {
+        console.warn("[buyer/signing-complete] email buyer failed", (err as any)?.message);
+      }
+    }
+
+    const adminEmails = parseEmails(process.env.ADMIN_NOTIFICATIONS_EMAIL);
+    if (adminEmails.length) {
+      const html = `
+        <p>Trade ${updated.id} is fully signed.</p>
+        <ul>
+          <li>District: ${updated.district}</li>
+          <li>Water type: ${updated.waterType ?? "—"}</li>
+          <li>Volume (AF): ${updated.volumeAf}</li>
+          <li>Price/AF: ${formatUsdCents(updated.pricePerAf)}</li>
+        </ul>
+        <p><a href="${tradeLinkForSeller}">View trade in Water Traders</a></p>
+      `;
+      try {
+        await sendEmail({ to: adminEmails, subject: `Trade ${updated.id} ready for admin review`, html });
+      } catch (err) {
+        console.warn("[buyer/signing-complete] admin email failed", (err as any)?.message);
+      }
+    }
+
+    const districtEmails = parseEmails(process.env.DISTRICT_NOTIFICATIONS_EMAIL);
+    if (districtEmails.length) {
+      const html = `
+        <p>The buyer and seller have both signed trade ${updated.id} for ${updated.district}.</p>
+        <p>Please review and confirm the transfer in your system.</p>
+      `;
+      try {
+        await sendEmail({ to: districtEmails, subject: `Action needed: trade ${updated.id} pending district confirmation`, html });
+      } catch (err) {
+        console.warn("[buyer/signing-complete] district email failed", (err as any)?.message);
+      }
+    }
+
+    const base = process.env.NEXT_PUBLIC_APP_URL || req.nextUrl.origin;
+    const redirectUrl = new URL(`/t/${updated.id}`, base);
+    redirectUrl.searchParams.set("role", "buyer");
+    redirectUrl.searchParams.set("action", "buyer-signature-complete");
+    const redirectToken = token || updated.buyerToken;
+    if (redirectToken) {
+      redirectUrl.searchParams.set("token", redirectToken);
+    }
+
+    return NextResponse.redirect(redirectUrl);
+  } catch (err) {
+    console.error("[buyer/signing-complete] unexpected", err);
+    const fallback = new URL(appUrl(`/t/${id}`));
+    fallback.searchParams.set("action", "signing-error");
+    fallback.searchParams.set("role", "buyer");
+    if (token) fallback.searchParams.set("token", token);
+    return NextResponse.redirect(fallback);
+  }
+}

--- a/frontend/app/api/trades/[id]/seller/accept/route.ts
+++ b/frontend/app/api/trades/[id]/seller/accept/route.ts
@@ -1,62 +1,38 @@
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+import { randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { prisma } from "@/lib/prisma";
-import { Party, TradeStatus, TransactionStatus } from "@prisma/client";
-import { getViewer, findTradeByAnyId } from "@/lib/trade";
+import { Party, SignatureProgress, TradeStatus, TransactionStatus } from "@prisma/client";
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { sendEmail, appUrl, renderBuyerAcceptedEmail } from "@/lib/email";
-import { createBuyerSignatureLink } from "@/lib/trade";
+
+import { appUrl, sendEmail } from "@/lib/email";
+import { prisma } from "@/lib/prisma";
+import {
+  createSellerSignatureLink,
+  ensureTradeFromAnyIdOrCreate,
+  findTradeByAnyId,
+  getViewer,
+} from "@/lib/trade";
 
 /** Accept Trade.id OR Transaction.id and create a Trade if missing */
-async function ensureTradeFromAnyIdOrThrow(id: string) {
-  const existing = await findTradeByAnyId(id);
-  if (existing) return existing;
-
-  const txn = await prisma.transaction.findUnique({
-    where: { id },
-    include: { listing: { select: { id: true, district: true, title: true, waterType: true } } },
-  });
-  if (!txn) return null;
-
-  const listingId = txn.listing?.id ?? null;
-  const district =
-    (txn as any).districtSnapshot ??
-    txn.listing?.district ??
-    null;
-
-  if (!listingId || !district) {
-    throw new Error("Cannot create Trade: missing listingId or district on Transaction/Listing.");
-  }
-
-  const created = await prisma.trade.create({
-    data: {
-      transactionId: txn.id,
-      listingId,
-      district,
-      sellerUserId: (txn as any).sellerUserId ?? (txn as any).sellerId ?? undefined,
-      buyerUserId:  (txn as any).buyerUserId  ?? (txn as any).buyerId  ?? undefined,
-      pricePerAf:   (txn as any).pricePerAf   ?? (txn as any).pricePerAF ?? undefined,
-      volumeAf:     (txn as any).volumeAf     ?? (txn as any).acreFeet   ?? undefined,
-      status: TradeStatus.OFFERED,
-      round: 0,
-    } as any,
-  });
-
-  return created;
-}
-
-function pickTxnPendingBuyerSig():
+function pickTxnPendingSellerSig():
   (typeof TransactionStatus)[keyof typeof TransactionStatus] | null {
   const TXS: any = TransactionStatus;
-  return TXS.PENDING_BUYER_SIGNATURE ?? TXS.PENDING_SIGNATURE ?? TXS.PENDING ?? TXS.ACCEPTED ?? null;
+  return TXS.PENDING_SELLER_SIGNATURE ?? TXS.PENDING_SIGNATURE ?? TXS.PENDING ?? TXS.ACCEPTED ?? null;
 }
 
-function pickAcceptedPendingTradeStatus():
+function pickAcceptedPendingSellerStatus():
   (typeof TradeStatus)[keyof typeof TradeStatus] {
   const TS: any = TradeStatus;
-  return TS.ACCEPTED_PENDING_BUYER_SIGNATURE ?? TS.ACCEPTED ?? TS.PENDING ?? TS.OFFERED;
+  return (
+    TS.ACCEPTED_PENDING_SELLER_SIGNATURE ??
+    TS.ACCEPTED_PENDING_SIGNATURE ??
+    TS.ACCEPTED_PENDING_BUYER_SIGNATURE ??
+    TS.ACCEPTED ??
+    TS.PENDING ??
+    TS.OFFERED
+  );
 }
 
 export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
@@ -99,20 +75,23 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     // Accept Trade.id or Transaction.id; create Trade if needed
     let trade;
     try {
-      trade = await ensureTradeFromAnyIdOrThrow(rawId);
+      trade = await ensureTradeFromAnyIdOrCreate(rawId);
     } catch (e: any) {
       return NextResponse.json({ error: e?.message || "Unable to create Trade", errorCode: "CREATE_FAILED" }, { status: 422 });
     }
     if (!trade) {
-      return NextResponse.json({ error: "Not found", errorCode: "NOT_FOUND", hint: "No Trade or Transaction with this id" }, { status: 404 });
+      return NextResponse.json(
+        { error: "Not found", errorCode: "NOT_FOUND", hint: "No Trade or Transaction with this id" },
+        { status: 404 }
+      );
     }
 
     // AuthZ: seller or admin or valid token
     const viewer = await getViewer(req as any, trade as any);
-    let tokenMatchViaBody = false;
-    if (viewer.role !== "seller" && bodyToken && (trade as any).sellerToken && bodyRole === "seller") {
-      tokenMatchViaBody = bodyToken === (trade as any).sellerToken;
-    }
+    const sellerToken = (trade as any).sellerToken || "";
+    const bodyRoleIsSeller = (bodyRole || "").toLowerCase() === "seller";
+    const tokenMatchViaBody =
+      viewer.role !== "seller" && bodyRoleIsSeller && bodyToken && sellerToken && bodyToken === sellerToken;
 
     let allow = viewer.role === "seller" || tokenMatchViaBody;
     let actedByAdmin: { adminUserId: string; adminEmail?: string | null } | null = null;
@@ -162,16 +141,20 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     }
 
     // Transition Trade -> accepted/pending buyer signature
-    const TRADE_ACCEPTED = pickAcceptedPendingTradeStatus();
+    const TRADE_ACCEPTED = pickAcceptedPendingSellerStatus();
     const updated = await prisma.trade.update({
       where: { id: trade.id },
       data: {
         status: TRADE_ACCEPTED,
         lastActor: Party.SELLER,
         version: { increment: 1 },
+        sellerSignStatus: SignatureProgress.REQUESTED,
+        buyerSignStatus: SignatureProgress.NONE,
+        sellerSignUrl: null,
+        buyerSignUrl: null,
         events: {
           create: {
-            id: crypto.randomUUID(),
+            id: randomUUID(),
             actor: "seller",
             kind: "ACCEPT",
             payload: { previousStatus: (trade as any).status, round: (trade as any).round, ...(actedByAdmin ? { actedByAdmin } : {}) },
@@ -197,7 +180,7 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     // Sync Transaction status (best-effort)
     if (updated.transactionId) {
       try {
-        const pending = pickTxnPendingBuyerSig();
+        const pending = pickTxnPendingSellerSig();
         if (pending) {
           await prisma.transaction.update({ where: { id: updated.transactionId }, data: { status: pending } });
         }
@@ -206,18 +189,22 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
       }
     }
 
-    // Create embedded sign URL for buyer
+    // Create embedded sign URL for seller to sign immediately
     let signLink: string | null = null;
     try {
-      signLink = await createBuyerSignatureLink(updated.id, (trade as any).buyerToken);
+      signLink = await createSellerSignatureLink(updated.id, sellerToken);
+      await prisma.trade.update({
+        where: { id: updated.id },
+        data: { sellerSignUrl: signLink },
+      });
     } catch (e: any) {
       return NextResponse.json(
-        { error: "Failed to create buyer sign URL", errorCode: "SIGN_URL_FAILED", details: e?.message || "Unknown error" },
+        { error: "Failed to create seller sign URL", errorCode: "SIGN_URL_FAILED", details: e?.message || "Unknown error" },
         { status: 502 }
       );
     }
 
-    // ---- Notify buyer (existing) + NEW: confirmation to seller ----
+    // ---- Notify buyer (status update) + seller confirmation with sign link ----
     const [buyerLocal, sellerLocal] = await Promise.all([
       prisma.user.findUnique({ where: { id: updated.buyerUserId || "" }, select: { email: true, name: true, clerkId: true } }),
       prisma.user.findUnique({ where: { id: updated.sellerUserId || "" }, select: { name: true, clerkId: true, email: true } }),
@@ -246,42 +233,33 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     }
 
     const viewLinkForBuyer = appUrl(
-      `/t/${updated.id}?role=buyer${(trade as any).buyerToken ? `&token=${(trade as any).buyerToken}` : ""}&action=review`
+      `/t/${updated.id}?role=buyer${(trade as any).buyerToken ? `&token=${(trade as any).buyerToken}` : ""}&action=awaiting-seller-signature`
     );
 
     if (buyerEmail) {
-      const { html, preheader } = renderBuyerAcceptedEmail({
-        buyerName: buyerName || "Buyer",
-        sellerName: sellerName || "Seller",
-        offer: {
-          listingTitle: updated.windowLabel || "Offer Terms",
-          district: updated.district || "",
-          waterType: updated.waterType ?? undefined,
-          volumeAf: updated.volumeAf,
-          pricePerAf: updated.pricePerAf,
-          windowLabel: updated.windowLabel ?? undefined,
-        },
-        signLink: signLink!,
-        viewLink: viewLinkForBuyer,
-      });
-
+      const html = `
+        <p>Hi ${buyerName || "Buyer"},</p>
+        <p>The seller accepted your offer and is signing the transfer agreement now.</p>
+        <p>We’ll email you as soon as it’s your turn to sign.</p>
+        <p><a href="${viewLinkForBuyer}">View the transaction</a></p>
+      `;
       try {
-        await sendEmail({ to: buyerEmail, subject: "Seller accepted — review & sign", html, preheader });
+        await sendEmail({ to: buyerEmail, subject: "Seller accepted — awaiting seller signature", html });
       } catch (e) {
-        console.warn("[seller/accept] sendEmail (buyer) failed:", (e as any)?.message);
+        console.warn("[seller/accept] sendEmail (buyer status) failed:", (e as any)?.message);
       }
     }
 
-    // NEW: Seller confirmation
     if (sellerEmail) {
       const sellerViewLink = appUrl(`/t/${updated.id}?role=seller${updated.sellerToken ? `&token=${updated.sellerToken}` : ""}`);
       const html = `
         <p>Hi ${sellerName || "Seller"},</p>
-        <p>You accepted the buyer’s offer. We’ve notified the buyer and shared the signature link.</p>
-        <p>Thread: <a href="${sellerViewLink}">${sellerViewLink}</a></p>
+        <p>You accepted the buyer’s offer. Please sign the water transfer agreement to move forward.</p>
+        <p><a href="${signLink}">Sign with DocuSign</a></p>
+        <p>Need to review details? <a href="${sellerViewLink}">View the transaction</a>.</p>
       `;
       try {
-        await sendEmail({ to: sellerEmail, subject: "You accepted the offer", html });
+        await sendEmail({ to: sellerEmail, subject: "Please sign the transfer agreement", html });
       } catch (e) {
         console.warn("[seller/accept] sendEmail (seller confirm) failed:", (e as any)?.message);
       }
@@ -290,19 +268,18 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
     // Friendly redirect target
     const base = process.env.NEXT_PUBLIC_APP_URL || req.nextUrl.origin;
     const inUrl = new URL(req.url);
-    const token = inUrl.searchParams.get("token") || undefined;
-    const role = inUrl.searchParams.get("role") || (tokenMatchViaBody ? "seller" : "seller");
+    const token = inUrl.searchParams.get("token") || (tokenMatchViaBody ? bodyToken : undefined) || undefined;
 
     const redirectUrl = new URL(`/t/${updated.id}`, base);
-    redirectUrl.searchParams.set("role", role);
-    redirectUrl.searchParams.set("action", "awaiting-buyer-signature");
+    redirectUrl.searchParams.set("role", "seller");
+    redirectUrl.searchParams.set("action", "awaiting-seller-signature");
     if (token) redirectUrl.searchParams.set("token", token);
 
     return NextResponse.json({
       ok: true,
       tradeId: updated.id,
       status: updated.status,
-      message: "Awaiting buyer signature",
+      message: "Awaiting seller signature",
       redirectUrl: redirectUrl.toString(),
       signLink,
     });

--- a/frontend/app/api/trades/[id]/seller/signing-complete/route.ts
+++ b/frontend/app/api/trades/[id]/seller/signing-complete/route.ts
@@ -1,0 +1,191 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { SignatureProgress, TradeStatus, TransactionStatus } from "@prisma/client";
+import { clerkClient } from "@clerk/nextjs/server";
+
+import { appUrl, renderBuyerAcceptedEmail, sendEmail } from "@/lib/email";
+import { prisma } from "@/lib/prisma";
+import { createBuyerSignatureLink } from "@/lib/trade";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function pickAcceptedPendingBuyerStatus(): (typeof TradeStatus)[keyof typeof TradeStatus] {
+  const TS: any = TradeStatus;
+  return (
+    TS.ACCEPTED_PENDING_BUYER_SIGNATURE ??
+    TS.ACCEPTED_PENDING_SIGNATURE ??
+    TS.ACCEPTED ??
+    TS.PENDING ??
+    TS.OFFERED
+  );
+}
+
+function pickTxnPendingBuyerSig(): (typeof TransactionStatus)[keyof typeof TransactionStatus] | null {
+  const TXS: any = TransactionStatus;
+  return TXS.PENDING_BUYER_SIGNATURE ?? TXS.PENDING_SIGNATURE ?? TXS.PENDING ?? TXS.ACCEPTED ?? null;
+}
+
+async function resolveContact(userId?: string | null) {
+  if (!userId) return { email: "", name: "" };
+  const user = await prisma.user.findUnique({ where: { id: userId }, select: { email: true, name: true, clerkId: true } });
+  if (!user) return { email: "", name: "" };
+
+  let { email = "", name = "" } = user;
+
+  if ((!email || !name) && user.clerkId) {
+    try {
+      const clerkUser = await clerkClient.users.getUser(user.clerkId);
+      name = name || clerkUser.firstName || clerkUser.username || "";
+      const primary = clerkUser.emailAddresses?.find(e => e.id === clerkUser.primaryEmailAddressId)?.emailAddress;
+      email = email || primary || clerkUser.emailAddresses?.[0]?.emailAddress || "";
+    } catch {
+      // ignore clerk failures
+    }
+  }
+
+  return { email, name };
+}
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const id = (params.id || "").trim();
+  if (!id) {
+    return NextResponse.json({ error: "Missing trade id" }, { status: 400 });
+  }
+
+  const token = req.nextUrl.searchParams.get("token") || "";
+
+  try {
+    const trade = await prisma.trade.findUnique({
+      where: { id },
+      include: {
+        listing: { select: { title: true, district: true, waterType: true } },
+      },
+    });
+
+    if (!trade) {
+      return NextResponse.json({ error: "Trade not found" }, { status: 404 });
+    }
+
+    if (trade.sellerToken && token && token !== trade.sellerToken) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const buyerSignLink = await createBuyerSignatureLink(trade.id, trade.buyerToken);
+
+    const updated = await prisma.trade.update({
+      where: { id: trade.id },
+      data: {
+        status: pickAcceptedPendingBuyerStatus(),
+        sellerSignStatus: SignatureProgress.SIGNED,
+        buyerSignStatus: SignatureProgress.REQUESTED,
+        buyerSignUrl: buyerSignLink,
+        events: {
+          create: {
+            id: randomUUID(),
+            actor: "seller",
+            kind: "SELLER_SIGNED",
+            payload: {
+              previousStatus: trade.status,
+              sellerSignStatus: trade.sellerSignStatus,
+              buyerSignStatus: trade.buyerSignStatus,
+            },
+          },
+        },
+      },
+      select: {
+        id: true,
+        buyerUserId: true,
+        sellerUserId: true,
+        sellerToken: true,
+        buyerToken: true,
+        district: true,
+        windowLabel: true,
+        waterType: true,
+        volumeAf: true,
+        pricePerAf: true,
+        transactionId: true,
+      },
+    });
+
+    if (updated.transactionId) {
+      try {
+        const nextStatus = pickTxnPendingBuyerSig();
+        if (nextStatus) {
+          await prisma.transaction.update({
+            where: { id: updated.transactionId },
+            data: {
+              status: nextStatus,
+            },
+          });
+        }
+      } catch (err) {
+        console.warn("[seller/signing-complete] transaction update failed", (err as any)?.message);
+      }
+    }
+
+    const [{ email: buyerEmail, name: buyerName }, { email: sellerEmail, name: sellerName }] = await Promise.all([
+      resolveContact(updated.buyerUserId),
+      resolveContact(updated.sellerUserId),
+    ]);
+
+    const offerSummary = {
+      listingTitle: trade.windowLabel || trade.listing?.title || "Offer",
+      district: trade.district,
+      waterType: trade.waterType ?? undefined,
+      volumeAf: trade.volumeAf,
+      pricePerAf: trade.pricePerAf,
+      windowLabel: trade.windowLabel ?? undefined,
+    };
+
+    if (buyerEmail) {
+      const { html, preheader } = renderBuyerAcceptedEmail({
+        buyerName: buyerName || "Buyer",
+        sellerName: sellerName || "Seller",
+        offer: offerSummary,
+        signLink: buyerSignLink,
+        viewLink: appUrl(
+          `/t/${updated.id}?role=buyer${updated.buyerToken ? `&token=${updated.buyerToken}` : ""}&action=awaiting-buyer-signature`
+        ),
+      });
+      try {
+        await sendEmail({ to: buyerEmail, subject: "Seller signed — your turn to sign", html, preheader });
+      } catch (err) {
+        console.warn("[seller/signing-complete] sendEmail buyer failed", (err as any)?.message);
+      }
+    }
+
+    if (sellerEmail) {
+      const html = `
+        <p>Hi ${sellerName || "Seller"},</p>
+        <p>Thanks for signing the agreement. We’ve alerted the buyer to sign next.</p>
+        <p>You can monitor progress <a href="${appUrl(`/t/${updated.id}?role=seller${
+          updated.sellerToken ? `&token=${updated.sellerToken}` : ""
+        }`)}">on Water Traders</a>.</p>
+      `;
+      try {
+        await sendEmail({ to: sellerEmail, subject: "Signature captured — awaiting buyer", html });
+      } catch (err) {
+        console.warn("[seller/signing-complete] sendEmail seller failed", (err as any)?.message);
+      }
+    }
+
+    const base = process.env.NEXT_PUBLIC_APP_URL || req.nextUrl.origin;
+    const redirectUrl = new URL(`/t/${updated.id}`, base);
+    redirectUrl.searchParams.set("role", "seller");
+    redirectUrl.searchParams.set("action", "seller-signature-complete");
+    const redirectToken = token || updated.sellerToken;
+    if (redirectToken) {
+      redirectUrl.searchParams.set("token", redirectToken);
+    }
+
+    return NextResponse.redirect(redirectUrl);
+  } catch (err) {
+    console.error("[seller/signing-complete] unexpected", err);
+    const fallback = new URL(appUrl(`/t/${id}`));
+    fallback.searchParams.set("action", "signing-error");
+    fallback.searchParams.set("role", "seller");
+    if (token) fallback.searchParams.set("token", token);
+    return NextResponse.redirect(fallback);
+  }
+}

--- a/frontend/app/t/[id]/page.tsx
+++ b/frontend/app/t/[id]/page.tsx
@@ -16,7 +16,16 @@ function getParam(sp: PageProps["searchParams"], k: string) {
 }
 
 const ROLE_SET = new Set(["buyer", "seller"]);
-const ACTION_SET = new Set(["review", "counter", "decline", "awaiting-buyer-signature"]);
+const ACTION_SET = new Set([
+  "review",
+  "counter",
+  "decline",
+  "awaiting-buyer-signature",
+  "awaiting-seller-signature",
+  "seller-signature-complete",
+  "buyer-signature-complete",
+  "signing-error",
+]);
 
 export default function Page({ params, searchParams }: PageProps) {
   const id = params.id ?? "";

--- a/frontend/components/trade/AcceptButton.tsx
+++ b/frontend/components/trade/AcceptButton.tsx
@@ -24,13 +24,14 @@ export default function AcceptButton({
   confirmMessage = "Accept this offer?",
   onSuccess,
   successTitle = "Offer Accepted",
-  successMessage = "The offer was accepted. Next steps have been sent to both parties.",
+  successMessage = "The offer was accepted. Sign the agreement to keep things moving.",
 }: Props) {
   const router = useRouter();
   const [busy, setBusy] = React.useState(false);
   const [err, setErr] = React.useState<string | null>(null);
   const [ok, setOk] = React.useState<string | null>(null);
   const [showSuccess, setShowSuccess] = React.useState(false);
+  const [signUrl, setSignUrl] = React.useState<string | null>(null);
 
   async function handleClick() {
     if (busy) return;
@@ -65,7 +66,8 @@ export default function AcceptButton({
         throw new Error(message);
       }
 
-      setOk(data?.message || "Awaiting buyer signature");
+      setOk(data?.message || "Awaiting seller signature");
+      setSignUrl(data?.signLink || null);
       setShowSuccess(true);
       onSuccess?.();
       // NOTE: wait to refresh until user clicks OK in the modal
@@ -107,19 +109,44 @@ export default function AcceptButton({
       {showSuccess && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center p-4" aria-modal="true" role="dialog">
           <div className="absolute inset-0 bg-black/40" onClick={() => setShowSuccess(false)} />
-          <div className="relative z-[110] w-full max-w-sm rounded-2xl border border-slate-200 bg-white p-6 shadow-xl text-center">
+          <div className="relative z-[110] w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-xl text-center">
             <h2 className="text-lg font-semibold text-slate-900">{successTitle}</h2>
             <p className="mt-2 text-sm text-slate-600">{successMessage}</p>
-            <button
-              onClick={() => {
-                setShowSuccess(false);
-                if (onSuccess) onSuccess();
-                else router.refresh();
-              }}
-              className="mt-4 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700"
-            >
-              OK
-            </button>
+            {signUrl ? (
+              <div className="mt-5 flex flex-col items-stretch gap-3 sm:flex-row">
+                <button
+                  onClick={() => {
+                    window.location.assign(signUrl);
+                  }}
+                  className="flex-1 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700"
+                >
+                  Go to DocuSign
+                </button>
+                <button
+                  onClick={() => {
+                    setShowSuccess(false);
+                    setSignUrl(null);
+                    if (onSuccess) onSuccess();
+                    else router.refresh();
+                  }}
+                  className="flex-1 rounded-xl border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+                >
+                  I’ll sign later
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => {
+                  setShowSuccess(false);
+                  setSignUrl(null);
+                  if (onSuccess) onSuccess();
+                  else router.refresh();
+                }}
+                className="mt-4 rounded-xl bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700"
+              >
+                OK
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/frontend/components/trade/ProgressTracker.tsx
+++ b/frontend/components/trade/ProgressTracker.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+
+export type TradeProgressStep = {
+  id: string;
+  title: string;
+  description?: string;
+  status: "complete" | "current" | "upcoming";
+};
+
+function Indicator({ status }: { status: TradeProgressStep["status"] }) {
+  if (status === "complete") {
+    return (
+      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+        ✓
+      </span>
+    );
+  }
+  if (status === "current") {
+    return (
+      <span className="flex h-6 w-6 items-center justify-center rounded-full border-2 border-emerald-500 text-emerald-600">
+        •
+      </span>
+    );
+  }
+  return <span className="flex h-6 w-6 items-center justify-center rounded-full border border-slate-300 text-slate-400">•</span>;
+}
+
+export default function TradeProgressTracker({ steps }: { steps: TradeProgressStep[] }) {
+  if (!steps.length) return null;
+
+  return (
+    <ol className="space-y-3">
+      {steps.map((step) => (
+        <li
+          key={step.id}
+          className="flex items-start gap-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-3 shadow-sm"
+        >
+          <Indicator status={step.status} />
+          <div className="flex-1">
+            <div className="text-sm font-semibold text-slate-800">{step.title}</div>
+            {step.description ? <p className="mt-1 text-xs text-slate-600">{step.description}</p> : null}
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/frontend/components/trade/TradeShell.tsx
+++ b/frontend/components/trade/TradeShell.tsx
@@ -10,6 +10,7 @@ import DeclineButton from "@/components/trade/DeclineButton";
 import CounterButton from "@/components/trade/CounterButton";
 import AcceptButton from "@/components/trade/AcceptButton";
 import BuyNowConfirmButton from "@/components/trade/BuyNowConfirmButton";
+import TradeProgressTracker, { TradeProgressStep } from "@/components/trade/ProgressTracker";
 
 type Props = {
   tradeId: string;
@@ -105,6 +106,99 @@ function buildUrl(base: string, opts: { token?: string; role?: "buyer" | "seller
   return url.pathname + (url.search ? url.search : "");
 }
 
+type ProgressInput = {
+  tradeStatus?: string | null;
+  sellerSignStatus?: string | null;
+  buyerSignStatus?: string | null;
+  txStatus?: string | null;
+};
+
+function buildProgressSteps(input: ProgressInput): TradeProgressStep[] {
+  const tradeStatus = (input.tradeStatus ?? "").toUpperCase();
+  const sellerSignStatus = (input.sellerSignStatus ?? "NONE").toUpperCase();
+  const buyerSignStatus = (input.buyerSignStatus ?? "NONE").toUpperCase();
+  const txStatus = (input.txStatus ?? "").toUpperCase();
+
+  const acceptedComplete = tradeStatus.startsWith("ACCEPTED") || tradeStatus === "FULLY_EXECUTED";
+  const sellerSigned = sellerSignStatus === "SIGNED";
+  const sellerRequested = sellerSignStatus === "REQUESTED";
+  const buyerSigned = buyerSignStatus === "SIGNED";
+  const buyerRequested = buyerSignStatus === "REQUESTED";
+  const adminComplete = txStatus === "APPROVED" || txStatus === "FUNDS_RELEASED";
+  const adminActive = txStatus === "COMPLIANCE_REVIEW";
+  const districtComplete = txStatus === "FUNDS_RELEASED";
+  const districtActive = txStatus === "APPROVED";
+
+  const sellerDescription = sellerSigned
+    ? "Seller signature received."
+    : sellerRequested
+    ? "Waiting for the seller to complete DocuSign."
+    : acceptedComplete
+    ? "Seller can sign the agreement now."
+    : "Seller signature begins once the offer is accepted.";
+
+  const buyerDescription = buyerSigned
+    ? "Buyer signature received."
+    : buyerRequested
+    ? "Waiting for the buyer to complete DocuSign."
+    : sellerSigned
+    ? "Buyer will be invited to sign next."
+    : "Buyer signature begins after the seller signs.";
+
+  let adminDescription = "Water Traders reviews the agreement after both signatures.";
+  if (adminActive) adminDescription = "Water Traders compliance team is reviewing the agreement.";
+  else if (adminComplete) adminDescription = "Admin review complete.";
+
+  let districtDescription = "The water district confirms once admin approval is complete.";
+  if (districtActive) districtDescription = "Awaiting water district confirmation.";
+  if (districtComplete) districtDescription = "Water district confirmed and funds are being released.";
+
+  const raw = [
+    {
+      id: "accepted",
+      title: "Offer accepted",
+      description: "Seller accepted the buyer’s offer.",
+      complete: acceptedComplete,
+    },
+    {
+      id: "seller-signature",
+      title: "Seller signature",
+      description: sellerDescription,
+      complete: sellerSigned,
+    },
+    {
+      id: "buyer-signature",
+      title: "Buyer signature",
+      description: buyerDescription,
+      complete: buyerSigned,
+    },
+    {
+      id: "admin-review",
+      title: "Admin approval",
+      description: adminDescription,
+      complete: adminComplete || districtComplete,
+    },
+    {
+      id: "district",
+      title: "Water district confirmation",
+      description: districtDescription,
+      complete: districtComplete,
+    },
+  ];
+
+  let foundCurrent = false;
+  return raw.map((step) => {
+    if (step.complete) {
+      return { id: step.id, title: step.title, description: step.description, status: "complete" as const };
+    }
+    if (!foundCurrent) {
+      foundCurrent = true;
+      return { id: step.id, title: step.title, description: step.description, status: "current" as const };
+    }
+    return { id: step.id, title: step.title, description: step.description, status: "upcoming" as const };
+  });
+}
+
 export default async function TradeShell(props: Props) {
   try {
     const {
@@ -139,9 +233,23 @@ export default async function TradeShell(props: Props) {
     // linked Trade (optional)
     const linkedTrade = await prisma.trade.findFirst({
       where: { transactionId: tx.id },
-      select: { id: true, status: true },
+      select: {
+        id: true,
+        status: true,
+        sellerSignStatus: true,
+        buyerSignStatus: true,
+        sellerSignUrl: true,
+        buyerSignUrl: true,
+      },
     });
     const tradeIdLinked = linkedTrade?.id ?? null;
+
+    const progressSteps = buildProgressSteps({
+      tradeStatus: linkedTrade?.status ?? tx.status,
+      sellerSignStatus: linkedTrade?.sellerSignStatus,
+      buyerSignStatus: linkedTrade?.buyerSignStatus,
+      txStatus: tx.status,
+    });
 
     // resolve viewer role
     let viewerRole: "buyer" | "seller" | "guest" =
@@ -172,6 +280,11 @@ export default async function TradeShell(props: Props) {
     const status = tx.status ?? "—";
     const isBuyNow = tx.type === "BUY_NOW";
 
+    const sellerSignStatus = `${linkedTrade?.sellerSignStatus ?? "NONE"}`;
+    const buyerSignStatus = `${linkedTrade?.buyerSignStatus ?? "NONE"}`;
+    const sellerSignUrl = linkedTrade?.sellerSignUrl ?? "";
+    const buyerSignUrl = linkedTrade?.buyerSignUrl ?? "";
+
     // endpoints
     const idForActions = tradeIdLinked || tx.id;
     const acceptUrlSeller = buildUrl(`/api/trades/${idForActions}/seller/accept`, {
@@ -197,6 +310,65 @@ export default async function TradeShell(props: Props) {
     const isReview = action?.toLowerCase?.() === "review";
     const hideInlineBuyNowFinal = hideInlineBuyNow || isReview;
 
+    const actionLower = action?.toLowerCase?.() ?? "";
+    let banner: React.ReactNode = null;
+    if (actionLower === "awaiting-seller-signature") {
+      banner = (
+        <div className="mt-6 rounded-xl border border-amber-300 bg-amber-50 p-4 text-amber-900">
+          <div className="font-semibold">Awaiting seller signature</div>
+          <p className="mt-1 text-sm">Sign the agreement so the buyer can review next.</p>
+          {viewerRole === "seller" && sellerSignUrl ? (
+            <div className="mt-3">
+              <a
+                href={sellerSignUrl}
+                className="inline-flex items-center justify-center rounded-lg bg-emerald-700 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-800"
+              >
+                Resume DocuSign
+              </a>
+            </div>
+          ) : null}
+        </div>
+      );
+    } else if (actionLower === "seller-signature-complete") {
+      banner = (
+        <div className="mt-6 rounded-xl border border-emerald-300 bg-emerald-50 p-4 text-emerald-900">
+          <div className="font-semibold">Seller signature captured</div>
+          <p className="mt-1 text-sm">We invited the buyer to sign and will notify you when it’s complete.</p>
+        </div>
+      );
+    } else if (actionLower === "awaiting-buyer-signature") {
+      banner = (
+        <div className="mt-6 rounded-xl border border-amber-300 bg-amber-50 p-4 text-amber-900">
+          <div className="font-semibold">Awaiting buyer signature</div>
+          <p className="mt-1 text-sm">The buyer has the DocuSign link and will sign next.</p>
+          {viewerRole === "buyer" && buyerSignUrl ? (
+            <div className="mt-3">
+              <a
+                href={buyerSignUrl}
+                className="inline-flex items-center justify-center rounded-lg bg-emerald-700 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-800"
+              >
+                Open DocuSign
+              </a>
+            </div>
+          ) : null}
+        </div>
+      );
+    } else if (actionLower === "buyer-signature-complete") {
+      banner = (
+        <div className="mt-6 rounded-xl border border-emerald-300 bg-emerald-50 p-4 text-emerald-900">
+          <div className="font-semibold">All signatures captured</div>
+          <p className="mt-1 text-sm">Our team is coordinating admin approval and district confirmation.</p>
+        </div>
+      );
+    } else if (actionLower === "signing-error") {
+      banner = (
+        <div className="mt-6 rounded-xl border border-rose-300 bg-rose-50 p-4 text-rose-900">
+          <div className="font-semibold">We couldn’t verify the signing status</div>
+          <p className="mt-1 text-sm">Please refresh or contact support if the issue persists.</p>
+        </div>
+      );
+    }
+
     return (
       <div className="mx-auto max-w-3xl p-6">
         {/* Header */}
@@ -210,6 +382,8 @@ export default async function TradeShell(props: Props) {
             {isBuyNow ? <div className="flex items-center sm:ml-3" id="buy-now-header-slot" /> : null}
           </div>
         </div>
+
+        {banner}
 
         {/* Summary */}
         <div className="mt-5 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -314,6 +488,26 @@ export default async function TradeShell(props: Props) {
               )}
             </>
           )}
+        </div>
+
+        {/* Progress Tracker */}
+        <div className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-base font-semibold text-slate-900">Progress</h2>
+          </div>
+          <TradeProgressTracker steps={progressSteps} />
+
+          {viewerRole === "seller" && sellerSignStatus === "REQUESTED" && sellerSignUrl ? (
+            <div className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+              Ready to sign? <a href={sellerSignUrl} className="font-semibold underline">Open DocuSign</a>
+            </div>
+          ) : null}
+
+          {viewerRole === "buyer" && buyerSignStatus === "REQUESTED" && buyerSignUrl ? (
+            <div className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+              It’s your turn. <a href={buyerSignUrl} className="font-semibold underline">Open DocuSign</a>
+            </div>
+          ) : null}
         </div>
 
         {/* Disclaimer */}

--- a/frontend/components/trade/TradeShell.tsx
+++ b/frontend/components/trade/TradeShell.tsx
@@ -10,7 +10,7 @@ import DeclineButton from "@/components/trade/DeclineButton";
 import CounterButton from "@/components/trade/CounterButton";
 import AcceptButton from "@/components/trade/AcceptButton";
 import BuyNowConfirmButton from "@/components/trade/BuyNowConfirmButton";
-import TradeProgressTracker, { TradeProgressStep } from "@/components/trade/ProgressTracker";
+import TradeProgressTracker, { type TradeProgressStep } from "@/components/trade/ProgressTracker";
 
 type Props = {
   tradeId: string;

--- a/frontend/lib/trade.ts
+++ b/frontend/lib/trade.ts
@@ -248,11 +248,38 @@ async function getBuyerNameEmail(trade: Trade): Promise<{ name: string; email: s
   return { name, email };
 }
 
+async function getSellerNameEmail(trade: Trade): Promise<{ name: string; email: string }> {
+  const seller = trade.sellerUserId
+    ? await prisma.user.findUnique({ where: { id: trade.sellerUserId }, select: { name: true, email: true, clerkId: true } })
+    : null;
+
+  let name = seller?.name || "Seller";
+  let email = seller?.email || "";
+
+  if ((!email || !name) && seller?.clerkId) {
+    try {
+      const { clerkClient } = await import("@clerk/nextjs/server");
+      const u = await clerkClient.users.getUser(seller.clerkId);
+      name = name || u.firstName || u.username || "Seller";
+      const primary = u.emailAddresses?.find(e => e.id === u.primaryEmailAddressId)?.emailAddress;
+      email = email || primary || u.emailAddresses?.[0]?.emailAddress || "";
+    } catch { /* non-fatal */ }
+  }
+
+  if (!email) email = `no-email-seller+${trade.id}@example.com`;
+
+  return { name, email };
+}
+
 /**
  * Create a buyer embedded sign URL via Dropbox Sign (REST).
  * If envs are missing, returns your internal /sign page URL so the UI still navigates.
  */
-export async function createBuyerSignatureLink(tradeId: string, buyerToken?: string | null): Promise<string> {
+export async function createBuyerSignatureLink(
+  tradeId: string,
+  buyerToken?: string | null,
+  opts?: { redirectTo?: string }
+): Promise<string> {
   const apiKey = process.env.DROPBOX_SIGN_API_KEY;
   const clientId = process.env.DROPBOX_SIGN_CLIENT_ID;
 
@@ -284,6 +311,12 @@ export async function createBuyerSignatureLink(tradeId: string, buyerToken?: str
   );
   // Optional metadata
   form.set("metadata[tradeId]", tradeId);
+  const redirectTarget = opts?.redirectTo
+    ? opts.redirectTo
+    : `/api/trades/${tradeId}/buyer/signing-complete${
+        buyerToken ? `?token=${encodeURIComponent(buyerToken)}` : ""
+      }`;
+  form.set("signing_redirect_url", appUrl(redirectTarget));
 
   const createResp = await fetch(`${DBX_BASE}/signature_request/create_embedded`, {
     method: "POST",
@@ -351,13 +384,100 @@ export async function createBuyerSignatureLink(tradeId: string, buyerToken?: str
 }
 
 export async function createSellerSignatureLink(tradeId: string, sellerToken?: string | null): Promise<string> {
-  // For now we route sellers to the internal page; mirror buyer flow later if needed.
   const apiKey = process.env.DROPBOX_SIGN_API_KEY;
   const clientId = process.env.DROPBOX_SIGN_CLIENT_ID;
+
   if (!apiKey || !clientId) {
     return appUrl(`/sign/${tradeId}?role=seller${sellerToken ? `&token=${sellerToken}` : ""}`);
   }
-  return appUrl(`/sign/${tradeId}?role=seller${sellerToken ? `&token=${sellerToken}` : ""}`);
+
+  const trade = await prisma.trade.findUnique({ where: { id: tradeId }, include: { listing: true } });
+  if (!trade) throw new Error("Trade not found");
+
+  const { name, email } = await getSellerNameEmail(trade);
+
+  const form = new URLSearchParams();
+  const testMode = (process.env.DROPBOX_SIGN_TEST_MODE ?? "1") === "1";
+  form.set("client_id", clientId);
+  form.set("test_mode", testMode ? "1" : "0");
+  form.set("title", `Water Traders — Seller Signature ${tradeId}`);
+  form.set("subject", "Sign the transfer agreement");
+  form.set("message", "Please sign to continue the transaction.");
+  form.set("signers[0][email_address]", email);
+  form.set("signers[0][name]", name);
+  form.set("signers[0][order]", "0");
+  form.append(
+    "file_url[]",
+    process.env.NEXT_PUBLIC_SAMPLE_PDF_URL ||
+      "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
+  );
+  form.set("metadata[tradeId]", tradeId);
+  const redirectTarget = `/api/trades/${tradeId}/seller/signing-complete${
+    sellerToken ? `?token=${encodeURIComponent(sellerToken)}` : ""
+  }`;
+  form.set("signing_redirect_url", appUrl(redirectTarget));
+
+  const createResp = await fetch(`${DBX_BASE}/signature_request/create_embedded`, {
+    method: "POST",
+    headers: {
+      Authorization: dbxAuthHeader(apiKey),
+      "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+      Accept: "application/json",
+    },
+    body: form.toString(),
+  });
+
+  const createText = await createResp.text();
+  let createBody: any = null;
+  try { createBody = createText ? JSON.parse(createText) : null; } catch {}
+
+  if (!createResp.ok) {
+    const msg =
+      createBody?.error?.error_name ||
+      createBody?.error ||
+      createResp.statusText ||
+      "Dropbox Sign create_embedded failed";
+    throw new Error(msg);
+  }
+
+  const signatureId =
+    createBody?.signature_request?.signatures?.[0]?.signature_id ||
+    createBody?.signatureRequest?.signatures?.[0]?.signature_id;
+
+  if (!signatureId) {
+    throw new Error("Dropbox Sign did not return a signature_id");
+  }
+
+  const signResp = await fetch(`${DBX_BASE}/embedded/sign_url/${encodeURIComponent(signatureId)}`, {
+    method: "GET",
+    headers: {
+      Authorization: dbxAuthHeader(apiKey),
+      Accept: "application/json",
+    },
+  });
+
+  const signText = await signResp.text();
+  let signBody: any = null;
+  try { signBody = signText ? JSON.parse(signText) : null; } catch {}
+
+  if (!signResp.ok) {
+    const msg =
+      signBody?.error?.error_name ||
+      signBody?.error ||
+      signResp.statusText ||
+      "Dropbox Sign embedded/sign_url failed";
+    throw new Error(msg);
+  }
+
+  const signUrl = signBody?.embedded?.sign_url || signBody?.embedded?.signUrl;
+  if (!signUrl) throw new Error("Dropbox Sign did not return a sign_url");
+
+  const cid = process.env.DROPBOX_SIGN_CLIENT_ID || process.env.NEXT_PUBLIC_DROPBOX_SIGN_CLIENT_ID;
+  const urlWithClient = cid
+    ? `${signUrl}${signUrl.includes("?") ? "&" : "?"}client_id=${encodeURIComponent(cid)}`
+    : signUrl;
+
+  return urlWithClient;
 }
 
 export async function getViewer(


### PR DESCRIPTION
## Summary
- reuse the shared trade creation helper when the seller accepts to keep the flow aligned with other routes
- normalize signing callbacks to use `randomUUID`, tidy imports, and keep seller token handling consistent
- ensure seller redirects include body tokens when accepting so resume links stay valid

## Testing
- `npm run lint` *(fails: Next.js binary unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f145eea7788321a619a938a39b9041